### PR TITLE
RHIDP-2172: Generic GitHub action and reusable workflow to be used to…

### DIFF
--- a/.github/workflows/export-dynamic-caller.yaml
+++ b/.github/workflows/export-dynamic-caller.yaml
@@ -48,69 +48,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-
-    name: Prepare
-    outputs:
-      node-version: ${{ steps.set-env-vars.outputs.NODE_VERSION }}
-      janus-cli-version: ${{ steps.set-env-vars.outputs.JANUS_CLI_VERSION }}
-      plugins-repo: ${{ steps.set-env-vars.outputs.PLUGINS_REPO }}
-      workspaces: ${{ steps.gather-workspaces.outputs.workspaces }}
-      upload-project-on-error: ${{ steps.set-env-vars.outputs.UPLOAD_PROJECT_ON_ERROR }}
-      overlay-branch: ${{ steps.set-env-vars.outputs.OVERLAY_BRANCH }}
-    steps:
-      - uses: actions/checkout@v4.2.2
-      - name: Set environment variables
-        id: set-env-vars
-        shell: bash
-        run: |
-          if [[ "${{  github.event.inputs.node-version }}" != "" ]]
-          then
-            echo "NODE_VERSION=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
-          else
-            NODE_VERSION=$(cat node-version 2> /dev/null)
-            NODE_VERSION=${NODE_VERSION:-20.x}
-            echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_OUTPUT
-          fi
-          if [[ "${{  github.event.inputs.janus-cli-version }}" != "" ]]
-          then
-            echo "JANUS_CLI_VERSION=${{ github.event.inputs.janus-cli-version }}" >> $GITHUB_OUTPUT
-          else
-            JANUS_CLI_VERSION=$(cat janus-cli-version 2> /dev/null)
-            JANUS_CLI_VERSION=${JANUS_CLI_VERSION:-1.13.1}
-            echo "JANUS_CLI_VERSION=$JANUS_CLI_VERSION" >> $GITHUB_OUTPUT
-          fi
-          if [[ "${{  github.event.inputs.plugins-repo }}" != "" ]]
-          then
-            echo "PLUGINS_REPO=${{ github.event.inputs.plugins-repo }}" >> $GITHUB_OUTPUT
-          else
-            PLUGINS_REPO=$(cat plugins-repo 2> /dev/null)
-            PLUGINS_REPO=${PLUGINS_REPO:-backstage/community-plugins}
-            echo "PLUGINS_REPO=$PLUGINS_REPO" >> $GITHUB_OUTPUT
-          fi
-          if [[ "${{  github.event.inputs.overlay-branch }}" != "" ]]
-          then
-            echo "OVERLAY_BRANCH=${{ github.event.inputs.overlay-branch }}" >> $GITHUB_OUTPUT
-          else
-            OVERLAY_BRANCH=${OVERLAY_BRANCH:-''}
-            echo "OVERLAY_BRANCH=$OVERLAY_BRANCH" >> $GITHUB_OUTPUT
-          fi
-          if [[ "${{  github.event.inputs.upload-project-on-error }}" != "" ]]
-          then
-            echo "UPLOAD_PROJECT_ON_ERROR='${{ github.event.inputs.upload-project-on-error }}'" >> $GITHUB_OUTPUT
-          else
-            echo "UPLOAD_PROJECT_ON_ERROR='false'" >> $GITHUB_OUTPUT
-          fi
   parent_export:
-    needs: prepare
     uses: redhat-developer/rhdh-plugin-export-backstage-community-plugins/.github/workflows/export-dynamic.yaml@main
     with:
-      node-version: ${{ needs.prepare.outputs.node-version }}
-      janus-cli-version: ${{ needs.prepare.outputs.janus-cli-version }}
-      plugins-repo: ${{ needs.prepare.outputs.plugins-repo }}      
-      upload-project-on-error: ${{ needs.prepare.outputs.upload-project-on-error == 'true' }}
-      overlay-branch: ${{ needs.prepare.outputs.overlay-branch }}
+      node-version: ${{ github.event.inputs.node-version }}
+      janus-cli-version: ${{ github.event.inputs.janus-cli-version }}
+      plugins-repo: ${{ github.event.inputs.plugins-repo }}
+      upload-project-on-error: ${{ github.event.inputs.upload-project-on-error == 'true' }}
+      overlay-branch: ${{ github.event.inputs.overlay-branch }}
 
     permissions:
       contents: write

--- a/.github/workflows/export-dynamic-caller.yaml
+++ b/.github/workflows/export-dynamic-caller.yaml
@@ -28,6 +28,13 @@ on:
         type: string
         required: false
         default: 'backstage/community-plugins'
+
+      overlay-branch:
+        description: Branch of the overlay structure (current branch by default).
+        type: string
+        required: false
+        default: ''
+
   push:
     tags:
       - "v*.*.*"
@@ -51,6 +58,7 @@ jobs:
       plugins-repo: ${{ steps.set-env-vars.outputs.PLUGINS_REPO }}
       workspaces: ${{ steps.gather-workspaces.outputs.workspaces }}
       upload-project-on-error: ${{ steps.set-env-vars.outputs.UPLOAD_PROJECT_ON_ERROR }}
+      overlay-branch: ${{ steps.set-env-vars.outputs.OVERLAY_BRANCH }}
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Set environment variables
@@ -81,6 +89,13 @@ jobs:
             PLUGINS_REPO=${PLUGINS_REPO:-backstage/community-plugins}
             echo "PLUGINS_REPO=$PLUGINS_REPO" >> $GITHUB_OUTPUT
           fi
+          if [[ "${{  github.event.inputs.overlay-branch }}" != "" ]]
+          then
+            echo "OVERLAY_BRANCH=${{ github.event.inputs.overlay-branch }}" >> $GITHUB_OUTPUT
+          else
+            OVERLAY_BRANCH=${OVERLAY_BRANCH:-''}
+            echo "OVERLAY_BRANCH=$OVERLAY_BRANCH" >> $GITHUB_OUTPUT
+          fi
           if [[ "${{  github.event.inputs.upload-project-on-error }}" != "" ]]
           then
             echo "UPLOAD_PROJECT_ON_ERROR='${{ github.event.inputs.upload-project-on-error }}'" >> $GITHUB_OUTPUT
@@ -93,8 +108,9 @@ jobs:
     with:
       node-version: ${{ needs.prepare.outputs.node-version }}
       janus-cli-version: ${{ needs.prepare.outputs.janus-cli-version }}
-      plugins-repo: ${{ needs.prepare.outputs.plugins-repo }}
+      plugins-repo: ${{ needs.prepare.outputs.plugins-repo }}      
       upload-project-on-error: ${{ needs.prepare.outputs.upload-project-on-error == 'true' }}
+      overlay-branch: ${{ needs.prepare.outputs.overlay-branch }}
 
     permissions:
       contents: write

--- a/.github/workflows/export-dynamic-caller.yaml
+++ b/.github/workflows/export-dynamic-caller.yaml
@@ -1,0 +1,105 @@
+name: Export Dynamic Plugin Packages (Caller)
+on:
+  workflow_dispatch:
+    inputs:
+      node-version:
+        description: node-version to execute the export
+        required: false
+        type: choice
+        default: '20.x'
+        options:
+          - '18.x'
+          - '20.x'
+
+      janus-cli-version:
+        description: Version of the janus-idp/cli package.
+        type: string
+        required: false
+        default: '^1.13.1'
+
+      upload-project-on-error:
+        description: Upload the complete project as a workflow artifact in case of error in order to troubleshoot.
+        required: false
+        type: boolean
+        default: false
+
+      plugins-repo:
+        description: Target Community Plugins repository to export plugins from
+        type: string
+        required: false
+        default: 'backstage/community-plugins'
+  push:
+    tags:
+      - "v*.*.*"
+
+  pull_request:
+    branches:
+      - 'releases/**'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    name: Prepare
+    outputs:
+      node-version: ${{ steps.set-env-vars.outputs.NODE_VERSION }}
+      janus-cli-version: ${{ steps.set-env-vars.outputs.JANUS_CLI_VERSION }}
+      plugins-repo: ${{ steps.set-env-vars.outputs.PLUGINS_REPO }}
+      workspaces: ${{ steps.gather-workspaces.outputs.workspaces }}
+      upload-project-on-error: ${{ steps.set-env-vars.outputs.UPLOAD_PROJECT_ON_ERROR }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: Set environment variables
+        id: set-env-vars
+        shell: bash
+        run: |
+          if [[ "${{  github.event.inputs.node-version }}" != "" ]]
+          then
+            echo "NODE_VERSION=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
+          else
+            NODE_VERSION=$(cat node-version 2> /dev/null)
+            NODE_VERSION=${NODE_VERSION:-20.x}
+            echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{  github.event.inputs.janus-cli-version }}" != "" ]]
+          then
+            echo "JANUS_CLI_VERSION=${{ github.event.inputs.janus-cli-version }}" >> $GITHUB_OUTPUT
+          else
+            JANUS_CLI_VERSION=$(cat janus-cli-version 2> /dev/null)
+            JANUS_CLI_VERSION=${JANUS_CLI_VERSION:-1.13.1}
+            echo "JANUS_CLI_VERSION=$JANUS_CLI_VERSION" >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{  github.event.inputs.plugins-repo }}" != "" ]]
+          then
+            echo "PLUGINS_REPO=${{ github.event.inputs.plugins-repo }}" >> $GITHUB_OUTPUT
+          else
+            PLUGINS_REPO=$(cat plugins-repo 2> /dev/null)
+            PLUGINS_REPO=${PLUGINS_REPO:-backstage/community-plugins}
+            echo "PLUGINS_REPO=$PLUGINS_REPO" >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{  github.event.inputs.upload-project-on-error }}" != "" ]]
+          then
+            echo "UPLOAD_PROJECT_ON_ERROR='${{ github.event.inputs.upload-project-on-error }}'" >> $GITHUB_OUTPUT
+          else
+            echo "UPLOAD_PROJECT_ON_ERROR='false'" >> $GITHUB_OUTPUT
+          fi
+  export:
+    needs: prepare
+    uses: redhat-developer/rhdh-plugin-export-backstage-community-plugins/.github/workflows/export-dynamic.yaml@main
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace: ${{ fromJSON(needs.prepare.outputs.workspaces) }}
+
+    with:
+      node-version: ${{ needs.prepare.outputs.node-version }}
+      janus-cli-version: ${{ needs.prepare.outputs.janus-cli-version }}
+      plugins-repo: ${{ needs.prepare.outputs.plugins-repo }}
+      upload-project-on-error: ${{ needs.prepare.outputs.upload-project-on-error == 'true' }}
+
+    permissions:
+      contents: write

--- a/.github/workflows/export-dynamic-caller.yaml
+++ b/.github/workflows/export-dynamic-caller.yaml
@@ -37,7 +37,7 @@ on:
       - 'releases/**'
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -87,7 +87,7 @@ jobs:
           else
             echo "UPLOAD_PROJECT_ON_ERROR='false'" >> $GITHUB_OUTPUT
           fi
-  export:
+  parent_export:
     needs: prepare
     uses: redhat-developer/rhdh-plugin-export-backstage-community-plugins/.github/workflows/export-dynamic.yaml@main
     with:

--- a/.github/workflows/export-dynamic-caller.yaml
+++ b/.github/workflows/export-dynamic-caller.yaml
@@ -15,7 +15,7 @@ on:
         description: Version of the janus-idp/cli package.
         type: string
         required: false
-        default: '^1.13.1'
+        default: '^1.18.0'
 
       upload-project-on-error:
         description: Upload the complete project as a workflow artifact in case of error in order to troubleshoot.
@@ -51,11 +51,11 @@ jobs:
   parent_export:
     uses: redhat-developer/rhdh-plugin-export-backstage-community-plugins/.github/workflows/export-dynamic.yaml@main
     with:
-      node-version: ${{ github.event.inputs.node-version }}
-      janus-cli-version: ${{ github.event.inputs.janus-cli-version }}
-      plugins-repo: ${{ github.event.inputs.plugins-repo }}
-      upload-project-on-error: ${{ github.event.inputs.upload-project-on-error == 'true' }}
-      overlay-branch: ${{ github.event.inputs.overlay-branch }}
+      node-version: ${{ inputs.node-version }}
+      janus-cli-version: ${{ inputs.janus-cli-version }}
+      plugins-repo: ${{ inputs.plugins-repo }}
+      upload-project-on-error: ${{ inputs.upload-project-on-error == 'true' }}
+      overlay-branch: ${{ inputs.overlay-branch }}
 
     permissions:
       contents: write

--- a/.github/workflows/export-dynamic-caller.yaml
+++ b/.github/workflows/export-dynamic-caller.yaml
@@ -90,11 +90,6 @@ jobs:
   export:
     needs: prepare
     uses: redhat-developer/rhdh-plugin-export-backstage-community-plugins/.github/workflows/export-dynamic.yaml@main
-    strategy:
-      fail-fast: false
-      matrix:
-        workspace: ${{ fromJSON(needs.prepare.outputs.workspaces) }}
-
     with:
       node-version: ${{ needs.prepare.outputs.node-version }}
       janus-cli-version: ${{ needs.prepare.outputs.janus-cli-version }}

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -31,6 +31,12 @@ on:
         required: true
         default: 'backstage/community-plugins'
 
+      overlay-branch:
+        description: Branch of the overlay structure (current branch by default).
+        type: string
+        required: false
+        default: ''
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -50,10 +56,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.2.2
+        if: ${{ github.event.inputs.overlay-branch == '' }} 
+
+      - uses: actions/checkout@v4.2.2
+        if: ${{ github.event.inputs.overlay-branch != '' }} 
+        with:
+          ref: ${{ github.event.inputs.overlay-branch }}
+
       - name: Set overlay_ref
         id: set-overlay-repo-ref 
         run: |
-          echo "OVERLAY_REPO_REF=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event.inputs.overlay-branch }}" != "" ]]
+          then
+            echo "OVERLAY_REPO_REF=${{ github.event.inputs.overlay-branch }}" >> $GITHUB_OUTPUT
+          else
+            echo "OVERLAY_REPO_REF=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set environment variables
         id: set-env-vars

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -5,14 +5,14 @@ on:
       node-version:
         description: node-version to execute the export
         type: string
-        required: true
-        default: '20.x'
+        required: false
+        default: ''
 
       janus-cli-version:
         description: Version of the janus-idp/cli package.
         type: string
-        required: true
-        default: '^1.18.0'
+        required: false
+        default: ''
 
       upload-project-on-error:
         description: Upload the complete project as a workflow artifact in case of error in order to troubleshoot.
@@ -28,8 +28,8 @@ on:
       plugins-repo:
         description: Target Community Plugins repository to export plugins from
         type: string
-        required: true
-        default: 'backstage/community-plugins'
+        required: false
+        default: ''
 
       overlay-branch:
         description: Branch of the overlay structure (current branch by default).
@@ -51,7 +51,6 @@ jobs:
       janus-cli-version: ${{ steps.set-env-vars.outputs.JANUS_CLI_VERSION }}
       plugins-repo: ${{ steps.set-env-vars.outputs.PLUGINS_REPO }}
       workspaces: ${{ steps.gather-workspaces.outputs.workspaces }}
-      upload-project-on-error: ${{ steps.set-env-vars.outputs.UPLOAD_PROJECT_ON_ERROR }}
       overlay-repo-ref: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
 
     steps:
@@ -77,10 +76,30 @@ jobs:
         id: set-env-vars
         shell: bash
         run: |
-          echo "NODE_VERSION=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
-          echo "UPLOAD_PROJECT_ON_ERROR='${{ github.event.inputs.upload-project-on-error }}'" >> $GITHUB_OUTPUT
-          echo "JANUS_CLI_VERSION=${{ github.event.inputs.janus-cli-version }}" >> $GITHUB_OUTPUT
-          echo "PLUGINS_REPO=${{ github.event.inputs.plugins-repo }}" >> $GITHUB_OUTPUT
+          if [[ "${{  github.event.inputs.node-version }}" != "" ]]
+          then
+            echo "NODE_VERSION=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
+          else
+            NODE_VERSION=$(cat node-version 2> /dev/null)
+            NODE_VERSION=${NODE_VERSION:-20.x}
+            echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{  github.event.inputs.janus-cli-version }}" != "" ]]
+          then
+            echo "JANUS_CLI_VERSION=${{ github.event.inputs.janus-cli-version }}" >> $GITHUB_OUTPUT
+          else
+            JANUS_CLI_VERSION=$(cat janus-cli-version 2> /dev/null)
+            JANUS_CLI_VERSION=${JANUS_CLI_VERSION:-1.13.1}
+            echo "JANUS_CLI_VERSION=$JANUS_CLI_VERSION" >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{  github.event.inputs.plugins-repo }}" != "" ]]
+          then
+            echo "PLUGINS_REPO=${{ github.event.inputs.plugins-repo }}" >> $GITHUB_OUTPUT
+          else
+            PLUGINS_REPO=$(cat plugins-repo 2> /dev/null)
+            PLUGINS_REPO=${PLUGINS_REPO:-backstage/community-plugins}
+            echo "PLUGINS_REPO=$PLUGINS_REPO" >> $GITHUB_OUTPUT
+          fi       
 
       - name: Gather workspaces
         id: gather-workspaces
@@ -132,7 +151,7 @@ jobs:
       overlay-repo-ref: ${{ needs.prepare.outputs.overlay-repo-ref }}
       node-version: ${{ needs.prepare.outputs.node-version }}
       janus-cli-version: ${{ needs.prepare.outputs.janus-cli-version }}
-      upload-project-on-error: ${{ needs.prepare.outputs.upload-project-on-error == 'true' }}
+      upload-project-on-error: ${{ github.event.inputs.upload-project-on-error == 'true' }}
 
     permissions:
       contents: write

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -4,12 +4,9 @@ on:
     inputs:
       node-version:
         description: node-version to execute the export
+        type: string
         required: true
-        type: choice
         default: '20.x'
-        options:
-          - '18.x'
-          - '20.x'
 
       janus-cli-version:
         description: Version of the janus-idp/cli package.

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -1,10 +1,10 @@
 name: Export Dynamic Plugin Packages
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       node-version:
         description: node-version to execute the export
-        required: false
+        required: true
         type: choice
         default: '20.x'
         options:
@@ -14,18 +14,12 @@ on:
       janus-cli-version:
         description: Version of the janus-idp/cli package.
         type: string
-        required: false
+        required: true
         default: '^1.18.0'
 
-      overlay-branch:
-        description: Branch of the overlay structure (current branch by default).
-        type: string
-        required: false
-        default: ''
-      
       upload-project-on-error:
         description: Upload the complete project as a workflow artifact in case of error in order to troubleshoot.
-        required: false
+        required: true
         type: boolean
         default: false
       
@@ -34,13 +28,11 @@ on:
         required: false
         type: string
 
-  push:
-    tags:
-      - "v*.*.*"
-
-  pull_request:
-    branches:
-      - 'releases/**'
+      plugins-repo:
+        description: Target Community Plugins repository to export plugins from
+        type: string
+        required: true
+        default: 'backstage/community-plugins'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -54,57 +46,36 @@ jobs:
     outputs:
       node-version: ${{ steps.set-env-vars.outputs.NODE_VERSION }}
       janus-cli-version: ${{ steps.set-env-vars.outputs.JANUS_CLI_VERSION }}
+      plugins-repo: ${{ steps.set-env-vars.outputs.PLUGINS_REPO }}
       workspaces: ${{ steps.gather-workspaces.outputs.workspaces }}
       upload-project-on-error: ${{ steps.set-env-vars.outputs.UPLOAD_PROJECT_ON_ERROR }}
       overlay-repo-ref: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        if: ${{ github.event.inputs.overlay-branch == '' }} 
-
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        if: ${{ github.event.inputs.overlay-branch != '' }} 
-        with:
-          ref: ${{ github.event.inputs.overlay-branch }}
-      
+      - uses: actions/checkout@v4.2.2
       - name: Set overlay_ref
         id: set-overlay-repo-ref 
         run: |
-          if [[ "${{ github.event.inputs.overlay-branch }}" != "" ]]
-          then
-            echo "OVERLAY_REPO_REF=${{ github.event.inputs.overlay-branch }}" >> $GITHUB_OUTPUT
-          else
-            echo "OVERLAY_REPO_REF=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
-    
+          echo "OVERLAY_REPO_REF=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
+
       - name: Set environment variables
         id: set-env-vars
         shell: bash
         run: |
-          if [[ "${{  github.event.inputs.node-version }}" != "" ]]
-          then
-            echo "NODE_VERSION=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
-            echo "UPLOAD_PROJECT_ON_ERROR='${{ github.event.inputs.upload-project-on-error }}'" >> $GITHUB_OUTPUT
-            echo "JANUS_CLI_VERSION=${{ github.event.inputs.janus-cli-version }}" >> $GITHUB_OUTPUT
-          else
-            NODE_VERSION=$(cat node-version 2> /dev/null)
-            NODE_VERSION=${NODE_VERSION:-20.x}
-            echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_OUTPUT
-            JANUS_CLI_VERSION=$(cat janus-cli-version 2> /dev/null)
-            JANUS_CLI_VERSION=${JANUS_CLI_VERSION:-1.18.0}
-            echo "JANUS_CLI_VERSION=$JANUS_CLI_VERSION" >> $GITHUB_OUTPUT
-            echo "UPLOAD_PROJECT_ON_ERROR='false'" >> $GITHUB_OUTPUT
-          fi
+          echo "NODE_VERSION=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
+          echo "UPLOAD_PROJECT_ON_ERROR='${{ github.event.inputs.upload-project-on-error }}'" >> $GITHUB_OUTPUT
+          echo "JANUS_CLI_VERSION=${{ github.event.inputs.janus-cli-version }}" >> $GITHUB_OUTPUT
+          echo "PLUGINS_REPO=${{ github.event.inputs.plugins-repo }}" >> $GITHUB_OUTPUT
 
       - name: Gather workspaces
         id: gather-workspaces
         shell: bash
         run: |
-          workspacePath=''
+          workspacePath=''\
           if [[ "${{ github.event.inputs.workspace-path }}" != "" ]]
           then
             workspacePath="${{  github.event.inputs.workspace-path }}"
-          elif [[ "${{ github.event_name }}" == 'pull_request' ]] && [[ "${{ github.head_ref }}" == "workspaces/"* ]]
+          elif [[ "${{ github.head_ref }}" == "workspaces/"* ]]
           then
             workspacePath="$(echo '${{ github.head_ref }}' | sed -e 's:workspaces/[^_]*__\(.*\)$:workspaces/\1:')"
           fi
@@ -139,7 +110,7 @@ jobs:
         workspace: ${{ fromJSON(needs.prepare.outputs.workspaces) }}
 
     with:
-      plugins-repo: backstage/community-plugins
+      plugins-repo: ${{ needs.prepare.outputs.plugins-repo }}
       plugins-repo-ref: ${{ matrix.workspace.plugins-repo-ref }}
       plugins-root: ${{ matrix.workspace.plugins-root }}
       overlay-repo: ${{ github.repository }}

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -16,7 +16,7 @@ on:
 
       upload-project-on-error:
         description: Upload the complete project as a workflow artifact in case of error in order to troubleshoot.
-        required: true
+        required: false
         type: boolean
         default: false
       
@@ -37,10 +37,6 @@ on:
         required: false
         default: ''
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
-
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -55,19 +51,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.2.2
-        if: ${{ github.event.inputs.overlay-branch == '' }} 
+        if: ${{ inputs.overlay-branch == '' }}
 
       - uses: actions/checkout@v4.2.2
-        if: ${{ github.event.inputs.overlay-branch != '' }} 
+        if: ${{ inputs.overlay-branch != '' }}
         with:
-          ref: ${{ github.event.inputs.overlay-branch }}
+          ref: ${{ inputs.overlay-branch }}
 
       - name: Set overlay_ref
         id: set-overlay-repo-ref 
         run: |
-          if [[ "${{ github.event.inputs.overlay-branch }}" != "" ]]
+          if [[ "${{ inputs.overlay-branch }}" != "" ]]
           then
-            echo "OVERLAY_REPO_REF=${{ github.event.inputs.overlay-branch }}" >> $GITHUB_OUTPUT
+            echo "OVERLAY_REPO_REF=${{ inputs.overlay-branch }}" >> $GITHUB_OUTPUT
           else
             echo "OVERLAY_REPO_REF=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
           fi
@@ -76,25 +72,25 @@ jobs:
         id: set-env-vars
         shell: bash
         run: |
-          if [[ "${{  github.event.inputs.node-version }}" != "" ]]
+          if [[ "${{  inputs.node-version }}" != "" ]]
           then
-            echo "NODE_VERSION=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
+            echo "NODE_VERSION=${{ inputs.node-version }}" >> $GITHUB_OUTPUT
           else
             NODE_VERSION=$(cat node-version 2> /dev/null)
             NODE_VERSION=${NODE_VERSION:-20.x}
             echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_OUTPUT
           fi
-          if [[ "${{  github.event.inputs.janus-cli-version }}" != "" ]]
+          if [[ "${{  inputs.janus-cli-version }}" != "" ]]
           then
-            echo "JANUS_CLI_VERSION=${{ github.event.inputs.janus-cli-version }}" >> $GITHUB_OUTPUT
+            echo "JANUS_CLI_VERSION=${{ inputs.janus-cli-version }}" >> $GITHUB_OUTPUT
           else
             JANUS_CLI_VERSION=$(cat janus-cli-version 2> /dev/null)
-            JANUS_CLI_VERSION=${JANUS_CLI_VERSION:-1.13.1}
+            JANUS_CLI_VERSION=${JANUS_CLI_VERSION:-1.18.0}
             echo "JANUS_CLI_VERSION=$JANUS_CLI_VERSION" >> $GITHUB_OUTPUT
           fi
-          if [[ "${{  github.event.inputs.plugins-repo }}" != "" ]]
+          if [[ "${{  inputs.plugins-repo }}" != "" ]]
           then
-            echo "PLUGINS_REPO=${{ github.event.inputs.plugins-repo }}" >> $GITHUB_OUTPUT
+            echo "PLUGINS_REPO=${{ inputs.plugins-repo }}" >> $GITHUB_OUTPUT
           else
             PLUGINS_REPO=$(cat plugins-repo 2> /dev/null)
             PLUGINS_REPO=${PLUGINS_REPO:-backstage/community-plugins}
@@ -106,9 +102,9 @@ jobs:
         shell: bash
         run: |
           workspacePath=''
-          if [[ "${{ github.event.inputs.workspace-path }}" != "" ]]
+          if [[ "${{ inputs.workspace-path }}" != "" ]]
           then
-            workspacePath="${{  github.event.inputs.workspace-path }}"
+            workspacePath="${{  inputs.workspace-path }}"
           elif [[ "${{ github.head_ref }}" == "workspaces/"* ]]
           then
             workspacePath="$(echo '${{ github.head_ref }}' | sed -e 's:workspaces/[^_]*__\(.*\)$:workspaces/\1:')"
@@ -151,7 +147,7 @@ jobs:
       overlay-repo-ref: ${{ needs.prepare.outputs.overlay-repo-ref }}
       node-version: ${{ needs.prepare.outputs.node-version }}
       janus-cli-version: ${{ needs.prepare.outputs.janus-cli-version }}
-      upload-project-on-error: ${{ github.event.inputs.upload-project-on-error == 'true' }}
+      upload-project-on-error: ${{ inputs.upload-project-on-error == 'true' }}
 
     permissions:
       contents: write

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -68,7 +68,7 @@ jobs:
         id: gather-workspaces
         shell: bash
         run: |
-          workspacePath=''\
+          workspacePath=''
           if [[ "${{ github.event.inputs.workspace-path }}" != "" ]]
           then
             workspacePath="${{  github.event.inputs.workspace-path }}"

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v4.2.2
 
       - name: Get published community plugins
         id: get-published-community-plugins
@@ -115,7 +115,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v4.2.2
 
       - name: Download workspaces json file
         uses: actions/download-artifact@v4


### PR DESCRIPTION
… export dynamic plugins from any repository

In this PR we separate the action from main so it can be called from a branch pull request. It also makes possible to configure the target repo, so it can be used with different repos that follow `backstage/community-plugins` repo structure.

The action to create pull requests to update plugins refs will also need to be updated since currently it is hardcoded to work only with `backstage/community-plugins` repo. 
